### PR TITLE
Add header icons

### DIFF
--- a/src/Widgets/EtherInterface.vala
+++ b/src/Widgets/EtherInterface.vala
@@ -22,7 +22,7 @@ public class Network.EtherInterface : Network.AbstractEtherInterface {
 
     public EtherInterface (NM.Client nm_client, NM.Device? _device) {
         device = _device;
-        ethernet_item = new Network.Widgets.Switch (display_title);
+        ethernet_item = new Network.Widgets.Switch (display_title, "network-wired-symbolic");
 
         notify["display-title"].connect (() => {
             ethernet_item.caption = display_title;

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -57,7 +57,7 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
 
     public ModemInterface (NM.Client nm_client, NM.Device? _device) {
         device = _device;
-        modem_item = new Network.Widgets.Switch (display_title);
+        modem_item = new Network.Widgets.Switch (display_title, "network-cellular-signal-excellent-symbolic");
 
         notify["display-title"].connect (() => {
             modem_item.caption = display_title;

--- a/src/Widgets/Switch.vala
+++ b/src/Widgets/Switch.vala
@@ -23,16 +23,18 @@ public class Network.Widgets.Switch : Network.Widgets.Container {
 
     public bool active { get; set; }
     public string caption { owned get; set; }
+    public string icon_name { owned get; set; }
 
     private Gtk.Label button_label;
+    private Gtk.Image button_image;
     private Gtk.Switch button_switch;
 
-    public Switch (string caption, bool active = false) {
-        Object (caption: caption, active: active);
+    public Switch (string caption, string icon_name, bool active = false) {
+        Object (caption: caption, icon_name: icon_name, active: active);
     }
 
-    public Switch.with_mnemonic (string caption, bool active = false) {
-        Object (caption: caption, active: active);
+    public Switch.with_mnemonic (string caption, string icon_name, bool active = false) {
+        Object (caption: caption, icon_name: icon_name, active: active);
         button_label.set_text_with_mnemonic (caption);
         button_label.set_mnemonic_widget (this);
     }
@@ -45,13 +47,16 @@ public class Network.Widgets.Switch : Network.Widgets.Container {
         button_switch.hexpand = true;
         button_switch.valign = Gtk.Align.CENTER;
 
+        button_image = new Gtk.Image.from_icon_name(icon_name, Gtk.IconSize.MENU);
+
         button_label = new Gtk.Label (null);
         button_label.halign = Gtk.Align.START;
         button_label.margin_start = 6;
         button_label.margin_end = 10;
 
-        content_widget.attach (button_label, 0, 0, 1, 1);
-        content_widget.attach (button_switch, 1, 0, 1, 1);
+        content_widget.attach (button_image, 0, 0, 1, 1);
+        content_widget.attach (button_label, 1, 0, 1, 1);
+        content_widget.attach (button_switch, 2, 0, 1, 1);
 
         clicked.connect (() => {
             toggle_switch ();

--- a/src/Widgets/Switch.vala
+++ b/src/Widgets/Switch.vala
@@ -23,7 +23,7 @@ public class Network.Widgets.Switch : Network.Widgets.Container {
 
     public bool active { get; set; }
     public string caption { owned get; set; }
-    public string icon_name { owned get; set; }
+    public string icon_name { owned get; construct; }
 
     private Gtk.Label button_label;
     private Gtk.Image button_image;

--- a/src/Widgets/Switch.vala
+++ b/src/Widgets/Switch.vala
@@ -47,7 +47,9 @@ public class Network.Widgets.Switch : Network.Widgets.Container {
         button_switch.hexpand = true;
         button_switch.valign = Gtk.Align.CENTER;
 
-        button_image = new Gtk.Image.from_icon_name(icon_name, Gtk.IconSize.MENU);
+        button_image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.MENU);
+        button_image.halign = Gtk.Align.CENTER;
+        button_image.valign = Gtk.Align.CENTER;
 
         button_label = new Gtk.Label (null);
         button_label.halign = Gtk.Align.START;

--- a/src/Widgets/VpnInterface.vala
+++ b/src/Widgets/VpnInterface.vala
@@ -41,7 +41,7 @@ public class Network.VpnInterface : Network.AbstractVpnInterface {
 
     construct {
         orientation = Gtk.Orientation.VERTICAL;
-        vpn_item = new Network.Widgets.Switch ("");
+        vpn_item = new Network.Widgets.Switch ("", "user-not-tracked-symbolic");
         vpn_item.get_style_context ().add_class ("h4");
         pack_start (vpn_item);
 

--- a/src/Widgets/WifiInterface.vala
+++ b/src/Widgets/WifiInterface.vala
@@ -43,7 +43,7 @@ public class Network.WifiInterface : Network.AbstractWifiInterface {
 
     construct {
         orientation = Gtk.Orientation.VERTICAL;
-        wifi_item = new Network.Widgets.Switch ("");
+        wifi_item = new Network.Widgets.Switch ("", "network-wireless-symbolic");
         wifi_item.get_style_context ().add_class ("h4");
         pack_start (wifi_item);
 


### PR DESCRIPTION
This will add an icon to each section switch. This will help to visually separate the different rows in the applet.

Preview image:
![budgie-network-applet-icons](https://user-images.githubusercontent.com/5157277/48295760-0dd5b180-e45d-11e8-9e0d-a83ad1e6de59.png)
I do not have the ability to show wireless networks or VPN's, sadly.

Please feel free to suggest any further changes!

Resolves #3 